### PR TITLE
Updated tests

### DIFF
--- a/src/app/pages/components/pokemon/resolver/pokemon.resolver.spec.ts
+++ b/src/app/pages/components/pokemon/resolver/pokemon.resolver.spec.ts
@@ -1,16 +1,31 @@
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { TestUtilitiesService } from '@services/application';
 import { pokemonResolver } from './pokemon.resolver';
-import { ResolveFn } from '@angular/router';
 import { TestBed } from '@angular/core/testing';
 
 describe('pokemonResolver', () => {
+  let route: ActivatedRouteSnapshot;
+  let state: RouterStateSnapshot;
+
   const executeResolver: ResolveFn<boolean> = (...resolverParameters) =>
     TestBed.runInInjectionContext(() => pokemonResolver(...resolverParameters));
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [TestUtilitiesService],
+    });
+
+    const testUtils = TestBed.inject(TestUtilitiesService);
+
+    route = testUtils.createActivatedRouteSnapshot({});
+    state = testUtils.createRouterStateSnapshot();
   });
 
   it('should be created', () => {
     expect(executeResolver).toBeTruthy();
+  });
+
+  it('should return true', () => {
+    expect(executeResolver(route, state)).toBe(true);
   });
 });

--- a/src/shared/data/services/application/index.ts
+++ b/src/shared/data/services/application/index.ts
@@ -1,1 +1,2 @@
+export * from './test-util/test-utilities.service';
 export * from './helper/helper.service';

--- a/src/shared/data/services/application/test-util/test-utilities.service.spec.ts
+++ b/src/shared/data/services/application/test-util/test-utilities.service.spec.ts
@@ -1,0 +1,29 @@
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { TestUtilitiesService } from './test-utilities.service';
+import { TestBed } from '@angular/core/testing';
+
+describe('TestUtilitiesService', () => {
+  let service: TestUtilitiesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+
+    service = TestBed.inject(TestUtilitiesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return an empty ActivatedRoutSnapshot mock object', () => {
+    expect(service.createActivatedRouteSnapshot({})).toEqual(
+      { data: {} } as ActivatedRouteSnapshot
+    );
+  });
+
+  it('should return an empty RouterStateSnapshot mock object', () => {
+    expect(service.createRouterStateSnapshot()).toEqual(
+      {} as RouterStateSnapshot
+    );
+  });
+});

--- a/src/shared/data/services/application/test-util/test-utilities.service.ts
+++ b/src/shared/data/services/application/test-util/test-utilities.service.ts
@@ -1,0 +1,15 @@
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class TestUtilitiesService {
+  constructor() {}
+
+  createActivatedRouteSnapshot(data: any): ActivatedRouteSnapshot {
+    return { data: { ...data } } as ActivatedRouteSnapshot;
+  }
+
+  createRouterStateSnapshot(): RouterStateSnapshot {
+    return {} as RouterStateSnapshot;
+  }
+}


### PR DESCRIPTION
This is a test coverage improvement PR which includes:

- a new testing utilities service located in [src/shared/data/services/application/test-util](https://github.com/jackmiller2708/playground/compare/test/improve-coverage?expand=1#diff-1f6317e3acc021cfaaf4b5972b01aff5fdf6a5977dbf561a0f2a8c4475606712), that also been fully tested
- an updated [test](https://github.com/jackmiller2708/playground/compare/test/improve-coverage?expand=1#diff-f38a34b918651dae345837f321aea7b6e54ac2d8d852b65b126c81569a5ce147) for `pokemon.resolver.ts` .