### PR TITLE
Update Pokemon Model

### DIFF
--- a/src/shared/components/molecules/pokemon-card/pokemon-card.component.html
+++ b/src/shared/components/molecules/pokemon-card/pokemon-card.component.html
@@ -1,6 +1,8 @@
 @if (dataSource) {
   <app-card>
-    <img [src]="dataSource.sprites.officialArtwork" height="200" width="200"/>
+    @if (asset) {
+      <img [ngSrc]="asset.location" [alt]="asset.name" height="200" width="200"/>
+    }
 
     <div class="flex flex-col gap-1 items-center p-3">
       <div>

--- a/src/shared/components/molecules/pokemon-card/pokemon-card.component.spec.ts
+++ b/src/shared/components/molecules/pokemon-card/pokemon-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PokemonCardComponent } from './pokemon-card.component';
+import { Pokemon } from '@models/domain';
 
 describe('PokemonCardComponent', () => {
   let component: PokemonCardComponent;
@@ -17,5 +18,49 @@ describe('PokemonCardComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should return default maxIdDigits as 4', () => {
+    expect(component.maxIdDigits).toBe(4);
+  });
+
+  it('should set maxIdDigits to be 10', () => {
+    component.maxIdDigits = 10;
+
+    expect(component.maxIdDigits).toBe(10);
+  });
+
+  it('should return default showEntryNo to be false', () => {
+    expect(component.showEntryNo).toBeFalse();
+  });
+
+  it('should set showEntryNo to be false', () => {
+    component.showEntryNo = true;
+
+    expect(component.showEntryNo).toBeTrue();
+  });
+
+  it('should return default dataSource to be falsy', () => {
+    expect(component.dataSource).toBeFalsy();
+  });
+
+  it('should set dataSource to be have Pokemon data', () => {
+    const pokemon = Pokemon();
+
+    component.dataSource = pokemon;
+
+    expect(component.dataSource).toEqual(pokemon);
+  });
+
+  it('should return default asset to be falsy', () => {
+    expect(component.asset).toBeFalsy();
+  });
+
+  it('should return Pokemon asset', () => {
+    const pokemon = Pokemon();
+
+    component.dataSource = pokemon;
+
+    expect(component.asset).toEqual(pokemon.assetsInfo.first());
   });
 });

--- a/src/shared/components/molecules/pokemon-card/pokemon-card.component.ts
+++ b/src/shared/components/molecules/pokemon-card/pokemon-card.component.ts
@@ -3,6 +3,7 @@ import { TypeBadgeComponent } from '../type-badge/type-badge.component';
 import { Component, Input } from '@angular/core';
 import { CardComponent } from '@components/atoms';
 import { PokeIdPipe } from '@pipes';
+import { AssetInfo } from '@interfaces/application';
 import { Pokemon } from '@interfaces/domain';
 
 const imports = [
@@ -22,12 +23,14 @@ const imports = [
 })
 export class PokemonCardComponent {
   private _dataSource: Pokemon | undefined;
+  private _pokemonAsset: AssetInfo | undefined;
   private _maxIdDigits: number | undefined;
   private _showEntryNo: boolean;
 
   @Input({ required: true })
   set dataSource(value: Pokemon) {
     this._dataSource = value;
+    this._pokemonAsset = value.assetsInfo.first();
   }
 
   get dataSource(): Pokemon | undefined {
@@ -50,6 +53,10 @@ export class PokemonCardComponent {
 
   get showEntryNo(): boolean {
     return this._showEntryNo;
+  }
+
+  get asset(): AssetInfo | undefined {
+    return this._pokemonAsset;
   }
 
   constructor() {

--- a/src/shared/data/interfaces/domain/pokemon/IPokemon.interface.ts
+++ b/src/shared/data/interfaces/domain/pokemon/IPokemon.interface.ts
@@ -1,6 +1,7 @@
 import { PokemonAbility, PokemonHeldItem, PokemonMove, PokemonSprites, PokemonStat, PokemonType, PokemonTypePast } from '.';
 import { NamedResource, VersionGameIndex } from '@interfaces/domain/utilities';
 import { RecordOf, List } from 'immutable';
+import { IHasAssets } from '@interfaces/application';
 /**
  * Pokémon are the creatures that inhabit the world of the Pokémon games.
  * They can be caught using Pokéballs and trained by battling with other
@@ -8,7 +9,7 @@ import { RecordOf, List } from 'immutable';
  * variant which makes it differ from other Pokémon of the same species,
  * such as base stats, available abilities and typings.
  */
-export interface IPokemon {
+export interface IPokemon extends IHasAssets {
   id: number;
   name: string;
   height: number;

--- a/src/shared/data/models/domain/pokemon/Pokemon.model.ts
+++ b/src/shared/data/models/domain/pokemon/Pokemon.model.ts
@@ -3,6 +3,7 @@ import { NamedResource, VersionGameIndex } from '../utilities';
 import { IPokemon, Pokemon as TPokemon } from '@interfaces/domain';
 import { IPokemon as IPokemonDto } from '@interfaces/dtos';
 import { AdaptableRecordFactory } from '@models/application/utilities';
+import { AssetInfo } from '@models/application/assets';
 import { List } from 'immutable';
 
 const defaultValues: IPokemon = {
@@ -17,6 +18,7 @@ const defaultValues: IPokemon = {
   pokedexEntry: undefined,
   sprites: PokemonSprites(),
   species: NamedResource(),
+  assetsInfo: List(),
   types: List(),
   stats: List(),
   abilities: List(),
@@ -68,6 +70,12 @@ const adaptor = (value?: IPokemonDto): TPokemon => {
     gameIndices: List(game_indices?.map(VersionGameIndex.adaptor)),
     heldItems: List(held_items?.map(PokemonHeldItem.adaptor)),
     pastTypes: List(past_types?.map(PokemonTypePast.adaptor)),
+    assetsInfo: List([
+      AssetInfo({
+        location: `official-artwork/${id}.png`,
+        name: `${name}-official-artwork`,
+      }),
+    ]),
   });
 };
 


### PR DESCRIPTION
This PR is made to update the `Pokemon` model to have additional `assetInfo` property due to recent assets migration - the pokemon artwork from the API to [ImageKit.io](https://imagekit.io/).